### PR TITLE
Update prom-cli and add process metrics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run Lint and Tests
 
 on: push
-
+ 
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         node-version: [14.x, 16.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A Fastify plugin for consuming @metrics/client (https://www.npmjs.com/package/@metrics/client) streams and rendering a prometheus scraping page",
   "main": "index.js",
   "scripts": {
-    "test": "tap",
-    "lint:format": "eslint --fix .",
+    "test": "tap --no-check-coverage",
+    "lint:fix": "eslint --fix .",
     "lint": "eslint ."
   },
   "repository": {
@@ -21,21 +21,22 @@
   "homepage": "https://github.com/finn-no/fastify-metrics-js-prometheus#readme",
   "devDependencies": {
     "@metrics/client": "^2.5.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-config-prettier": "^6.9.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.20.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "fastify": "3.2.1",
-    "prettier": "^1.19.1",
-    "prom-client": "12.0.0",
-    "supertest": "^4.0.2",
-    "tap": "^14.10.6"
+    "eslint-plugin-prettier": "^4.0.0",
+    "fastify": "3.21.1",
+    "prettier": "^2.4.0",
+    "prom-client": "13.2.0",
+    "supertest": "^6.1.6",
+    "tap": "^15.0.9"
   },
   "dependencies": {
     "@metrics/guard": "^1.0.1",
+    "@metrics/process": "^2.2.0",
     "@metrics/prometheus-consumer": "^3.0.0",
-    "fastify-plugin": "2.3.0",
-    "prometheus-gc-stats": "^0.6.2"
+    "abslog": "^2.4.0",
+    "fastify-plugin": "3.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -7,13 +7,31 @@ const supertest = require('supertest');
 const Metrics = require('@metrics/client');
 const plugin = require('./index');
 
+// Helper to delay requesting the app server with some milliseconds.
+// This is needed due to the system process metrics which needs to 
+// be collected before there is any data to provide. The system
+// process data are emitted on an interval an need some time to be
+// available.
+const delayedGet = (address, pathname, delay = 200) => new Promise((resolve, reject) => {
+        setTimeout(async () => {
+            const http = supertest(address);
+            const { text } = await http.get(pathname);
+            if (text) {
+                resolve(text);
+            } else {
+                reject(new Error('no response from server'));
+            }
+        }, delay);
+    })
+
 test('Plugin renders basic metrics page', async t => {
     const app = fastify();
     app.register(plugin, { client });
     const address = await app.listen();
-    const http = supertest(address);
-    const { text } = await http.get('/metrics');
+    const text = await delayedGet(address, '/metrics');
+    t.match(text, 'process_start_time_seconds');
     t.match(text, 'nodejs_heap_space_size_used_bytes');
+    t.match(text, 'process_open_fds');
     await app.close();
 });
 
@@ -21,9 +39,10 @@ test('Plugin renders basic metrics page on a different pathname', async t => {
     const app = fastify();
     app.register(plugin, { client, pathname: '/_/metrics' });
     const address = await app.listen();
-    const http = supertest(address);
-    const { text } = await http.get('/_/metrics');
+    const text = await delayedGet(address, '/_/metrics');
+    t.match(text, 'process_start_time_seconds');
     t.match(text, 'nodejs_heap_space_size_used_bytes');
+    t.match(text, 'process_open_fds');
     await app.close();
 });
 


### PR DESCRIPTION
This update is to support `prom-client` version 13.x. This is a breaking change. In this process `prometheus-gc-stats` is removed in favor of using the `@metrics/process` module.

All other dependencies is also update plus added `abslog` to support not passing in a logger.